### PR TITLE
Task16- integrate filtering packets in main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You will extract the core functional and non-functional requirements, and protot
 - Task12: add getting network interfaces connected to a certain network, Diogo and Bryan
 - Task14: Add support for filtering packets
 #### Sprint 6: Nov 2, 2022 - Nov 16, 2022
+- Task16: Integrate filtering packets in main class
 #### Project Presentation: Nov 28, 2022
 
 
@@ -60,7 +61,7 @@ You will extract the core functional and non-functional requirements, and protot
 - Task15: Determine next commands to add.
 #### WIP (Task name, team member(s) working on it) 
 - Task12: add getting network interfaces connected to a certain network, Diogo and Bryan
-- Task13: add filtering of packets by protocol, Atharva
+- Task16: Integrate filtering packets in main class, Atharva
 #### Tasks Done
 - Created repository
 - Added ReadMe file
@@ -76,6 +77,7 @@ You will extract the core functional and non-functional requirements, and protot
 - Task11: Set up general test class to implement samples and calling all tests in one class, Bryan
 - Task2: Create command line class to handle user input, Diogo
 - Task10: Add junit tests, Atharva
+- Task13: add filtering of packets by protocol, Atharva
 ### Running Instructions:
 
 ### File Structure:

--- a/src/main/java/com/softwaredesign/HelpFile.txt
+++ b/src/main/java/com/softwaredesign/HelpFile.txt
@@ -4,13 +4,15 @@ help command accessed:
 -> "-n get -s local" 
 	Outputs a numerated list of all network interfaces from local device where this program is running on.
 
-->  "-n listen [FLAG: -p OR -t] [OPTIONAL_FLAG: -w] [MAX_AMOUNT_OF_PACKETS or MAX_AMOUNT_OF_TIME] [NETWORK_INTERFACE_NUMBER]"
+->  "-n listen [FLAG: -p OR -t OR -f] [OPTIONAL_FLAG: -w] [MAX_AMOUNT_OF_PACKETS or MAX_AMOUNT_OF_TIME] [NETWORK_INTERFACE_NUMBER]"
 	Listens for packets on the given network.
 	Flags "-p" and "-t" are required only one per command.
 	>   "-p" will listen to packets until it reaches the max amount of packets given.
 	    Ex: ""-n listen -p 320 1", where 320 is the max amount of packets and 1 is the given network interface.
 	>   "-t" will listen to packets until it reaches the max amount of time given.
 	    Ex: "-n listen -t 320 1", where 320 is the max amount of time in SECONDS and 1 is the given network interface.
+	>   "-f" will filter packets until it reaches the max amount of time given.
+	    Ex: "-n listen -f 10 1", where 10 is the max amount of time in SECONDS and 1 is the given network interface.
 	>   "-w" will prompt to give a file name after retrieving packets to write them to a pcap file inside the project folder
 
 ->  "-n show packets"


### PR DESCRIPTION
I have integrated filtering functionality with main class. 
The command for filter looks like "-n listen -f 10 1", where 10 is the max amount of time in SECONDS and 1 is the given network interface.
Time limit is part of the command just to keep a bound on listening process. We don't want to keep it running indefinitely.
Help file is updated as well with some minor refactorings in code.

I have included README.md file in this commit as I am still not able to force push it directly to origin.
